### PR TITLE
Update CUDA to v11 and T-Rex to version 0.19.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ WORKDIR /tmp
 RUN mkdir t-rex && \
     apt update && apt install tar wget -y
 
-RUN wget https://github.com/trexminer/T-Rex/releases/download/0.19.12/t-rex-0.19.12-linux-cuda10.0.tar.gz && \
-    tar xf t-rex-0.19.12-linux-cuda10.0.tar.gz -C t-rex
+RUN wget https://github.com/trexminer/T-Rex/releases/download/0.19.12/t-rex-0.19.12-linux-cuda11.1.tar.gz && \
+    tar xf t-rex-0.19.12-linux-cuda11.1.tar.gz -C t-rex
 
 
-FROM nvidia/cuda:10.2-base
+FROM nvidia/cuda:11.2.2-base
 
 LABEL maintainer="Dockminer"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /tmp
 RUN mkdir t-rex && \
     apt update && apt install tar wget -y
 
-RUN wget https://github.com/trexminer/T-Rex/releases/download/0.19.12/t-rex-0.19.12-linux-cuda11.1.tar.gz && \
-    tar xf t-rex-0.19.12-linux-cuda11.1.tar.gz -C t-rex
+RUN wget https://github.com/trexminer/T-Rex/releases/download/0.19.14/t-rex-0.19.14-linux-cuda11.1.tar.gz && \
+    tar xf t-rex-0.19.14-linux-cuda11.1.tar.gz -C t-rex
 
 
 FROM nvidia/cuda:11.2.2-base

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ In default, the docker expose the 4067 port for HTTP and 4068 port for telnet co
 
 This image is built on top of the following softwares:
 
-- [Nvidia CUDA Container](https://gitlab.com/nvidia/container-images/cuda) v10.2
-- [T-Rex](https://github.com/trexminer/T-Rex) v0.19.12
+- [Nvidia CUDA Container](https://gitlab.com/nvidia/container-images/cuda) v11..2
+- [T-Rex](https://github.com/trexminer/T-Rex) v0.19.14


### PR DESCRIPTION
I had to update CUDA to v11 because T-Rex wasn't working with my RTX 3070 with CUDA 10.

`ERROR: Can't start miner, GeForce RTX 3070 (CC 8.6) is not supported by CUDA v10 build, use T-Rex compiled with CUDA v11.1 or newer`

I noticed there's a new version of T-Rex so I also updated it to the latest version.

I tested it locally and it's working fine for me.

Thanks for creating this image!